### PR TITLE
Add cast in f2.c (fixes compilation error with current gcc)

### DIFF
--- a/src/libj/f2.c
+++ b/src/libj/f2.c
@@ -112,7 +112,7 @@ static void jtfmt1(J jt,B e,I m,I d,C*s,I t,C*wv){D y;
    y=*(D*)wv; y=y?y:0.0;  /* -0 to 0 */
    if     (!memcmp(wv,&inf, SZD))strcpy(jt->th2buf,e?"  _" :' '==*s?" _" :"_" );
    else if(!memcmp(wv,&infm,SZD))strcpy(jt->th2buf,e?" __" :' '==*s?" __":"__");
-   else if(_isnan(*wv)          )strcpy(jt->th2buf,e?"  _.":' '==*s?" _.":"_.");
+   else if(_isnan(*(D*)wv)      )strcpy(jt->th2buf,e?"  _.":' '==*s?" _.":"_.");
    else sprintf(jt->th2buf,s,y);
 }}   /* format one number */
 


### PR DESCRIPTION
Looks like a gcc update caused it to fail on this code; wv is dereferenced as a C\* pointer when it should be D*.
